### PR TITLE
Add test host for use in demo and test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "exports": {
     "./host.js": "./src/host/host.js",
-    "./client.js": "./src/client/client.js"
+    "./client.js": "./src/client/client.js",
+    "./test-helpers/test-host.js": "./src/test-helpers/test-host.js"
   },
   "files": [
     "/src"

--- a/src/host/host-internal.js
+++ b/src/host/host-internal.js
@@ -66,7 +66,7 @@ function sendChangeEvent(type, changedValues) {
 	});
 }
 
-export function initialize() {
+export function initializeImpl() {
 	if (initialized) return;
 
 	window.addEventListener('message', handleContextRequestMessage);
@@ -75,7 +75,7 @@ export function initialize() {
 	initialized = true;
 }
 
-export function allowFrame(frame, origin) {
+function allowFrameImpl(frame, origin) {
 	if (!initialized) {
 		throw new LmsContextProviderError(`Can't register frame with id ${frame.id}. Context provider host has not been initialized.`);
 	}
@@ -87,7 +87,7 @@ export function allowFrame(frame, origin) {
 	allowedFrames.set(frame, origin);
 }
 
-export function registerPlugin(type, tryGetCallback, subscriptionCallback) {
+function registerPluginImpl(type, tryGetCallback, subscriptionCallback) {
 	if (!initialized) {
 		throw new LmsContextProviderError(`Can't register plugin with type ${type}. Context provider host has not been initialized.`);
 	}
@@ -107,7 +107,7 @@ export function registerPlugin(type, tryGetCallback, subscriptionCallback) {
 	}
 }
 
-export function reset() {
+function resetImpl() {
 	if (!initialized) return;
 
 	window.removeEventListener('message', handleContextRequestMessage);
@@ -119,3 +119,15 @@ export function reset() {
 
 	initialized = false;
 }
+
+export const contextHostMockWrapper = {
+	allowFrame: allowFrameImpl,
+	initialize: initializeImpl,
+	registerPlugin: registerPluginImpl,
+	reset: resetImpl
+};
+
+export const allowFrame = (frame, origin) => contextHostMockWrapper.allowFrame(frame, origin);
+export const initialize = () => contextHostMockWrapper.initialize();
+export const registerPlugin = (type, tryGetCallback, subscriptionCallback) => contextHostMockWrapper.registerPlugin(type, tryGetCallback, subscriptionCallback);
+export const reset = () => contextHostMockWrapper.reset();

--- a/src/test-helpers/test-host.js
+++ b/src/test-helpers/test-host.js
@@ -1,0 +1,47 @@
+import { allowFrame, initialize, registerPlugin, reset } from '../host/host-internal.js';
+
+console.warn('Using lms-context-provider test host, this is intended for demo pages and tests only');
+
+const contextMap = new Map();
+const subscriptions = new Map();
+
+export function addContext(name, newContext) {
+	initialize();
+
+	contextMap.set(name, newContext);
+
+	const getContext = () => contextMap.get(name);
+	const subscribe = (onChange, options) => {
+		const context = contextMap.get(name);
+
+		if (options?.sendImmediate) {
+			onChange(context);
+		}
+
+		if (!subscriptions.has(name)) subscriptions.set(name, []);
+		subscriptions.get(name).push(onChange);
+	};
+
+	registerPlugin(
+		name,
+		getContext,
+		subscribe
+	);
+}
+
+export function addFrame(frame, origin) {
+	initialize();
+	allowFrame(frame, origin);
+}
+
+export function modifyContext(name, newContext) {
+	if (contextMap.has(name)) contextMap.set(name, newContext);
+	subscriptions.get(name)?.forEach(callback => callback(newContext));
+}
+
+export function clear() {
+	contextMap.clear();
+	subscriptions.clear();
+	reset();
+}
+

--- a/test/test-host.test.js
+++ b/test/test-host.test.js
@@ -1,0 +1,128 @@
+import { addContext, addFrame, clear, modifyContext } from '../src/test-helpers/test-host.js';
+import { restore, spy } from 'sinon';
+import { contextHostMockWrapper } from '../src/host/host-internal.js';
+import { expect } from '@brightspace-ui/testing';
+
+const testContext = { test: 'context' };
+const testContextName = 'test-context';
+
+describe('lms-context-provider test-host', () => {
+
+	beforeEach(() => {
+		clear();
+		restore();
+	});
+
+	describe('add context', () => {
+
+		it('initializes the host when adding context', () => {
+			const hostSpy = spy(contextHostMockWrapper, 'initialize');
+
+			addContext();
+			expect(hostSpy).to.have.been.calledOnceWithExactly();
+		});
+
+		it('registers a plugin with the host', () => {
+			const hostSpy = spy(contextHostMockWrapper, 'registerPlugin');
+
+			addContext(testContextName, testContext);
+			expect(hostSpy).to.have.been.calledOnce;
+			expect(hostSpy.args[0]).to.have.length(3);
+
+			// Verify registerPlugin arguments
+			expect(hostSpy.args[0][0]).to.equal(testContextName);
+
+			// Verify tryGetCallback
+			const tryGetCallback = hostSpy.args[0][1];
+			const returnedContext = tryGetCallback();
+			expect(returnedContext).to.deep.equal(testContext);
+
+			// Verify subscriptionCallback
+			const subscriptionSpy = spy();
+			const subscriptionCallback = hostSpy.args[0][2];
+			subscriptionCallback(subscriptionSpy);
+
+			// Subscription callback shouldn't be executed without sendImmediate set
+			expect(subscriptionSpy).not.to.have.been.called;
+		});
+
+		it('registers a plugin that handles queued subscription requests', () => {
+			const hostSpy = spy(contextHostMockWrapper, 'registerPlugin');
+
+			addContext(testContextName, testContext);
+
+			// Verify subscriptionCallback
+			const subscriptionSpy = spy();
+			const subscriptionCallback = hostSpy.args[0][2];
+			subscriptionCallback(subscriptionSpy, { sendImmediate: true });
+
+			// Subscription callback should be executed when sendImmediate is set.
+			expect(subscriptionSpy).to.have.been.calledOnceWithExactly(testContext);
+		});
+
+	});
+
+	describe('modify context', () => {
+
+		const newContext = { otherTest: 'otherContext' };
+
+		it('modifies context on the host', () => {
+			const hostSpy = spy(contextHostMockWrapper, 'registerPlugin');
+			addContext(testContextName, testContext);
+
+			modifyContext(testContextName, newContext);
+
+			// Verify tryGetCallback returns new context
+			const tryGetCallback = hostSpy.args[0][1];
+			const returnedContext = tryGetCallback();
+			expect(returnedContext).to.deep.equal(newContext);
+		});
+
+		it('sends subscription events from the host when context is modified', () => {
+			const hostSpy = spy(contextHostMockWrapper, 'registerPlugin');
+			addContext(testContextName, testContext);
+
+			// Set subscription callback
+			const subscriptionSpy = spy();
+			const subscriptionCallback = hostSpy.args[0][2];
+			subscriptionCallback(subscriptionSpy);
+
+			modifyContext(testContextName, newContext);
+
+			// Verify subscription callback was called
+			expect(subscriptionSpy).to.have.been.calledOnceWithExactly(newContext);
+		});
+
+	});
+
+	describe('add frame', () => {
+
+		it('initializes the host when adding a frame', () => {
+			const hostSpy = spy(contextHostMockWrapper, 'initialize');
+
+			addFrame();
+			expect(hostSpy).to.have.been.calledOnceWithExactly();
+		});
+
+		it('allows the frame on the host', () => {
+			const testFrame = 'frame';
+			const testOrigin = 'origin';
+			const hostSpy = spy(contextHostMockWrapper, 'allowFrame');
+
+			addFrame(testFrame, testOrigin);
+			expect(hostSpy).to.have.been.calledOnceWithExactly(testFrame, testOrigin);
+		});
+
+	});
+
+	describe('clear', () => {
+
+		it('clears the host', () => {
+			const hostSpy = spy(contextHostMockWrapper, 'reset');
+			clear();
+			expect(hostSpy).to.have.been.calledOnceWithExactly();
+		});
+
+	});
+
+});


### PR DESCRIPTION
We want a nice automated way for consumers to set context data for their test and demo pages (where we're not loading BSI), so let's add a test host to the context provider's exports to enable that. The idea here is to take as much of the work out of the hands of consumers as possible, while also avoiding the need for faking LMS-specific implementations (like setting data attributes on the HTML element).