### PR TITLE
Pass an empty options object to the subscribe callback for a consistent consumer experience

### DIFF
--- a/src/host/host-internal.js
+++ b/src/host/host-internal.js
@@ -11,7 +11,7 @@ function handleContextRequest(type, options, subscribe) {
 
 	if (subscribe && !subscriptionQueue.has(type)) {
 		subscriptionQueue.add(type);
-		if (plugin && plugin.subscribe) plugin.subscribe(changedValues => sendChangeEvent(type, changedValues));
+		if (plugin && plugin.subscribe) plugin.subscribe(changedValues => sendChangeEvent(type, changedValues), {});
 	}
 
 	return plugin && plugin.tryGet && plugin.tryGet(options);

--- a/test/host.test.js
+++ b/test/host.test.js
@@ -187,7 +187,10 @@ describe('lms-context-provider host', () => {
 			const subscriptionMessageSpy = spy();
 			await sendFramedClientRequest(mockFrame, true, mockContextType, subscriptionMessageSpy);
 			expect(subscriptionSpy).to.have.been.calledOnce;
-			expect(subscriptionSpy.args[0]).to.have.length(1);
+			expect(subscriptionSpy.args[0]).to.have.length(2);
+
+			// Assert options argument
+			expect(subscriptionSpy.args[0][1]).to.deep.equal({});
 
 			// Trigger subscription callback in order to mimic a context change event
 			subscriptionSpy.args[0][0](testValues);
@@ -334,7 +337,10 @@ describe('lms-context-provider host', () => {
 			const subscriptionEventSpy = spy();
 			sendNonFramedClientRequest(mockContextType, subscriptionEventSpy);
 			expect(subscriptionSpy).to.have.been.calledOnce;
-			expect(subscriptionSpy.args[0]).to.have.length(1);
+			expect(subscriptionSpy.args[0]).to.have.length(2);
+
+			// Assert options argument
+			expect(subscriptionSpy.args[0][1]).to.deep.equal({});
 
 			// Trigger subscription callback in order to mimic a context change event
 			subscriptionSpy.args[0][0](testValues);


### PR DESCRIPTION
There's a bit of a conflict between the way I set this host stuff up and the BSI plugin registrations.

Specifically, for an already queued subscription request, the `options` object passed into the subscription callback looks like: `{ sendImmediate: true }`, but if the subscription event _isn't_ queued, then we don't send an options object at all.

Instead of forcing host plugins to care about the undefined case, I think it makes more sense to just always pass an options object, even if that's empty in the non-immediate case.