### PR TITLE
add publishConfig.registry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "version": "1.31.0",
   "repository": "https://github.com/BrightspaceUI/lms-context-provider.git",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
     "lint": "npm run lint:eslint",


### PR DESCRIPTION
Needed to publish to public NPM while reading packages from our proxy registry

HOD-4564